### PR TITLE
Add outcome counts

### DIFF
--- a/landavailability/lr/management/commands/import_polygons.py
+++ b/landavailability/lr/management/commands/import_polygons.py
@@ -9,12 +9,12 @@ class Command(ShapefileImportCommand):
     help = 'Import Land Registry Polygons from a *.shp file'
 
     def process_record(self, record):
-        print(record.record)
-
         try:
             poly = LRPoly.objects.get(title=record.record[1])
+            outcome = 'updated'
         except LRPoly.DoesNotExist:
             poly = LRPoly()
+            outcome = 'created'
             poly.title = record.record[1]
 
         poly.insert = datetime.strptime(record.record[2], '%Y-%m-%dT%H:%M:%S')
@@ -27,3 +27,5 @@ class Command(ShapefileImportCommand):
             poly.save()
         except Exception as e:
             print('Could not add: {0}'.format(record.record))
+            outcome = 'Error: could not save'
+        return outcome

--- a/landavailability/lr/management/commands/import_uprns.py
+++ b/landavailability/lr/management/commands/import_uprns.py
@@ -6,20 +6,21 @@ class Command(CSVImportCommand):
     help = 'Import UPRNs from a CSV file'
 
     def process_row(self, row):
-        print(row)
-
         try:
             poly = LRPoly.objects.get(title=row[0])
         except LRPoly.DoesNotExist:
             print(
-                'Cannot add UPRN {0} - Missing Title entry: {1}'
+                'Cannot add UPRN {0} - missing Title entry: {1}'
                 .format(row[1], row[0]))
+            outcome = 'ignored - uprn does not match any Title'
         else:
             try:
                 uprn = Uprn.objects.get(uprn=row[1])
+                outcome = 'updated'
             except Uprn.DoesNotExist:
                 uprn = Uprn()
                 uprn.uprn = row[1]
+                outcome = 'created'
 
             uprn.title = poly
 
@@ -27,3 +28,5 @@ class Command(CSVImportCommand):
                 uprn.save()
             except Exception as e:
                 print('Could not add: {0}'.format(row))
+                outcome = 'Error: could not save object'
+        return outcome

--- a/landavailability/lr/management/commands/importers.py
+++ b/landavailability/lr/management/commands/importers.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from pprint import pprint
+
 from django.core.management.base import BaseCommand, CommandError
 import csv
 import shapefile
@@ -29,8 +32,11 @@ class CSVImportCommand(BaseCommand):
                 if self.skip_header:
                     next(reader)
 
+                outcome_counts = defaultdict(int)
                 for row in reader:
-                    self.process_row(row)
+                    outcome = self.process_row(row)
+                    outcome_counts[outcome or 'processed'] += 1
+                    pprint(dict(outcome_counts))
 
 
 class ShapefileImportCommand(BaseCommand):
@@ -45,9 +51,13 @@ class ShapefileImportCommand(BaseCommand):
     def handle(self, *args, **options):
         shp_file_name = options.get('shp_file')
 
+        outcome_counts = defaultdict(int)
         if shp_file_name:
             reader = shapefile.Reader(shp_file_name)
             for record in reader.iterShapeRecords():
                 if record.shape.shapeType == shapefile.NULL:
+                    outcome_counts['no shapefile'] += 1
                     continue
-                self.process_record(record)
+                outcome = self.process_record(record)
+                outcome_counts[outcome or 'processed'] += 1
+                pprint(dict(outcome_counts))


### PR DESCRIPTION
Dunno if you like this, but it might be useful to keep count of what the outcomes of each run of the import loop e.g.
```
Cannot add UPRN 10024115804 - missing Title entry: HD514631
{'ignored - uprn does not match any Title': 10599, 'updated': 7}
Cannot add UPRN 10024115803 - missing Title entry: HD508374
{'ignored - uprn does not match any Title': 10600, 'updated': 7}
```
This could help to show that since I've only imported a few thousand polygons, when I import the uprns a handful DO import ok, but I'd probably miss that from the prints as they were before.